### PR TITLE
Fix prismarine-realms version to 1.2.0

### DIFF
--- a/patch-files/prismarine-web-client/package.json
+++ b/patch-files/prismarine-web-client/package.json
@@ -63,6 +63,7 @@
     "os-browserify": "^0.3.0",
     "path-browserify": "^1.0.1",
     "prismarine-viewer": "^1.22.0",
+    "prismarine-realms": "1.2.0",
     "process": "PrismarineJS/node-process",
     "standard": "^17.0.0",
     "stream-browserify": "^3.0.0",


### PR DESCRIPTION
Upgrade of prismarine-realms to 1.3.0 appears to be broken, so fix package use to 1.2.0